### PR TITLE
Bewerted version

### DIFF
--- a/ModSim_WS1718_Uebung_03_Julian_Stähle.ipynb
+++ b/ModSim_WS1718_Uebung_03_Julian_Stähle.ipynb
@@ -105,7 +105,7 @@
    },
    "outputs": [],
    "source": [
-    "2^51"
+    "2^51 # sehen Commit nachricht"
    ]
   },
   {
@@ -125,7 +125,7 @@
    },
    "outputs": [],
    "source": [
-    "False weil 0.3 nicht genau dargestellt werden kann da es ein float ist und nur auf höchstens 52 stellen genau dargestellt werden kann."
+    "False weil 0.3 nicht genau dargestellt werden kann da es ein float ist und nur auf höchstens 52 stellen genau dargestellt werden kann. # sehen Commit nachricht"
    ]
   }
  ],


### PR DESCRIPTION
Af2. # Begründung? (-5)

Af3. "weil 0.3 nicht genau dargestellt werden kann da es ein float ist und nur auf höchstens 52 stellen genau dargestellt werden kann."
Manche floats können aber durch 52 genau dargestellt werden, zu beispiel 1.0000000000000002. (-3)